### PR TITLE
fix: escape runtimepath on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "build": "rimraf dist && tsc -p . --outDir dist/esm && tsc -p . --module commonjs --outDir dist/cjs",
     "prepublishOnly": "yarn build",
-    "postinstall": "yarn build"
+    "postinstall": "yarn && yarn build"
   },
   "peerDependencies": {
     "vite": ">2.0.0-0"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   ],
   "scripts": {
     "build": "rimraf dist && tsc -p . --outDir dist/esm && tsc -p . --module commonjs --outDir dist/cjs",
-    "prepublishOnly": "yarn build"
+    "prepublishOnly": "yarn build",
+    "postinstall": "yarn build"
   },
   "peerDependencies": {
     "vite": ">2.0.0-0"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "build": "rimraf dist && tsc -p . --outDir dist/esm && tsc -p . --module commonjs --outDir dist/cjs",
     "prepublishOnly": "yarn build",
-    "postinstall": "yarn && yarn build"
+    "postinstall": "yarn build"
   },
   "peerDependencies": {
     "vite": ">2.0.0-0"

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -51,7 +51,7 @@ function getRuntimeLoader(opts: { root: string }) {
         })
         const exports = ['jsx', 'jsxs', 'Fragment']
         return [
-          `import * as jsxRuntime from '${runtimePath}'`,
+          `import * as jsxRuntime from ${JSON.stringify(runtimePath)}`,
           // We can't use `export * from` or else any callsite that uses
           // this module will be compiled to `jsxRuntime.exports.jsx`
           // instead of the more concise `jsx` alias.


### PR DESCRIPTION
First of all great little plugin you've got going here! I recently started building my project on different operating systems and noticed that builds were failing on windows. I tracked this issue down to missing path escapement on windows (backslashes were not escaped properly).
This PR addresses that by using JSON.stringify 