### PR TITLE
fix: properly escape path for windows

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -51,7 +51,7 @@ function getRuntimeLoader(opts: { root: string }) {
         })
         const exports = ['jsx', 'jsxs', 'Fragment']
         return [
-          `import * as jsxRuntime from '${runtimePath}'`,
+          `import * as jsxRuntime from ${JSON.stringify(runtimePath)}`,
           // We can't use `export * from` or else any callsite that uses
           // this module will be compiled to `jsxRuntime.exports.jsx`
           // instead of the more concise `jsx` alias.


### PR DESCRIPTION
This is a recreation of #6. It fixes a bug where the jsx-runtime could not be resolved on windows by properly escaping the path using JSON.stringify