### PR TITLE
Pass filename to the babel transform call

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -71,7 +71,7 @@ function getTransformer(opts: { sourceMaps?: boolean }) {
       const babel = await babelImport
 
       // Reverse-compile any React.createElement calls
-      let [ast, isCommonJS] = await viteReactJsx.restoreJSX(babel, code)
+      let [ast, isCommonJS] = await viteReactJsx.restoreJSX(babel, code, id)
 
       // Then apply the JSX automatic runtime transform
       if (ast) {
@@ -84,6 +84,7 @@ function getTransformer(opts: { sourceMaps?: boolean }) {
         const result = await babel.transformFromAstAsync(ast, undefined, {
           plugins,
           sourceMaps: opts.sourceMaps,
+          filename: id
         })
         if (result?.code) {
           return {
@@ -104,6 +105,7 @@ function getTransformer(opts: { sourceMaps?: boolean }) {
           [await babelTransformJsx, { runtime: 'automatic' }],
         ],
         sourceMaps: opts.sourceMaps,
+        filename: id
       })
       if (res?.code) {
         return {
@@ -129,7 +131,8 @@ let babelRestoreJSX: any
 /** Restore JSX from `React.createElement` calls */
 async function restoreJSX(
   babel: typeof import('@babel/core'),
-  code: string
+  code: string,
+  id: string
 ): Promise<RestoredJSX> {
   const [reactAlias, isCommonJS] = parseReactAlias(code)
   const reactJsxRE = new RegExp(
@@ -163,6 +166,7 @@ async function restoreJSX(
       plugins: ['jsx'],
     },
     plugins: [await babelRestoreJSX],
+    filename: id
   })
 
   return [result?.ast, isCommonJS]


### PR DESCRIPTION
Thanks for the plugin!

# Problem
Calls to babel transform without passing the filename causes babel to fail.
(According to the error stack and https://babeljs.io/docs/en/options#filename)

# Environment
@babel/core: ^7.14.6
NodeJS: v14.17.1
vite: ^2.3.7
vite-react-jsx: ^1.1.1

# Error stack
```
[vite:react-jsx] [BABEL] unknown: Preset /* your preset */ requires a filename to be set when babel is called directly,

babel.transform(code, { filename: 'file.ts', presets: [/* your preset */] });

See https://babeljs.io/docs/en/options#filename for more information.
file: src/index.tsx
error during build:
Error: [BABEL] unknown: Preset /* your preset */ requires a filename to be set when babel is called directly,

babel.transform(code, { filename: 'file.ts', presets: [/* your preset */] });

See https://babeljs.io/docs/en/options#filename for more information.
    at validateIfOptionNeedsFilename (node_modules/vite-react-jsx/node_modules/@babel/core/lib/config/full.js:295:11)
    at node_modules/vite-react-jsx/node_modules/@babel/core/lib/config/full.js:307:52
    at Array.forEach (<anonymous>)
    at validatePreset (node_modules/vite-react-jsx/node_modules/@babel/core/lib/config/full.js:307:25)
    at loadPresetDescriptor (node_modules/vite-react-jsx/node_modules/@babel/core/lib/config/full.js:314:3)
    at loadPresetDescriptor.next (<anonymous>)
    at recursePresetDescriptors (node_modules/vite-react-jsx/node_modules/@babel/core/lib/config/full.js:114:30)
    at recursePresetDescriptors.next (<anonymous>)
    at node_modules/vite-react-jsx/node_modules/@babel/core/lib/config/full.js:191:21
    at Generator.next (<anonymous>)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```