### PR TITLE
Support namespace import

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -20,7 +20,7 @@ export default function viteReactJsx(): Plugin {
         })
       } else {
         const jsxRE = /\.[tj]sx$/
-        const reactRE = /((^|\n)import React[ ,]|(^|\n)import \* as React[ ,])/
+        const reactRE = /((^|\n)import React[ ,]|(^|\n)import \* as React[ ,]/
 
         // Just use React.createElement in serve mode
         this.transform = function (code, id) {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -20,7 +20,7 @@ export default function viteReactJsx(): Plugin {
         })
       } else {
         const jsxRE = /\.[tj]sx$/
-        const reactRE = /(^|\n)import React[ ,]/
+        const reactRE = /((^|\n)import React[ ,]|(^|\n)import \* as React[ ,])/
 
         // Just use React.createElement in serve mode
         this.transform = function (code, id) {


### PR DESCRIPTION
I faced this error:

```sh
15:20:09 [vite] Internal server error: <path to file>: Identifier 'React' has already been declared. (1:39)

> 1 | import React from 'react'; import * as React from 'react';
    |                                        ^
  2 | import styled from 'styled-components';
```

https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html#removing-unused-react-imports